### PR TITLE
style: remove unnecessary `require_trailing_commas`

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -65,7 +65,6 @@ linter:
     - prefer_if_elements_to_conditional_expressions
     - prefer_int_literals
     - prefer_null_aware_method_calls
-    - require_trailing_commas
     - secure_pubspec_urls
     - sort_constructors_first
     - sort_pub_dependencies


### PR DESCRIPTION
Since dart 3.7 formatter defaults to tall style